### PR TITLE
Use fertilizer when young and mature are equal

### DIFF
--- a/CookieGardenHelper-reloaded/main.js
+++ b/CookieGardenHelper-reloaded/main.js
@@ -1150,7 +1150,7 @@ Game.registerMod("cookiegardenhelperreloaded",{
 			}
 			
 			var soilCombo = this.getSoilRotationCombo();
-			var targetSoil = young>matur?soilCombo[1]:soilCombo[2];
+			var targetSoil = young>=matur?soilCombo[1]:soilCombo[2];
 			
 			if( M.soil!=targetSoil && M.parent.amount>=M.soilsById[targetSoil].req && M.nextSoil<Date.now() ){
 				M.nextSoil=Date.now()+(Game.Has('Turbo-charged soil')?1:(1000*60*10));


### PR DESCRIPTION
If you're trying to unlock new seeds, and you have equal numbers of each base type of seed, and the seeds have different maturity times (for example, when trying to create Fool's Bolete from Green Rot, 4 ticks, and Doughshroom, 41 ticks), you can run into a situation where the Green Rot has all matured but the Doughshroom isn't even close yet. Currently, that triggers a switch to the mature soil (which in this case would likely be Wood Chips), but that switch is useless.

This change makes it so that if the young seeds and mature seeds are _equal_ in number, then we _remain_ on the first soil, to more efficiently handle the case I described.

There may be other use cases for which this change is bad; if so, please reject. This is just what I've been running into.